### PR TITLE
Remove whitespace in empty table.

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -46,7 +46,10 @@ export function tableRule(rule: Tag, comment: Comment) {
   let body = "";
   if (!isClass(comment)) {
     const fields = remove(comment.tags, (t) => t.type === "field");
-    body = "\n" + fields.map(generateField).join(",\n\n") + "\n";
+    body =
+      fields.length === 0
+        ? ""
+        : "\n" + fields.map(generateField).join(",\n\n") + "\n";
   }
   return `${tableName} = {${body}}`;
 }

--- a/src/test/preserve-indentation.test.ts
+++ b/src/test/preserve-indentation.test.ts
@@ -17,9 +17,7 @@ testMembers(
     ---- Foo
     ---  - Bar
     ---    - Baz
-    List = {
-
-    }
+    List = {}
   `
 );
 

--- a/src/test/table.test.ts
+++ b/src/test/table.test.ts
@@ -1,0 +1,38 @@
+import dedent from "dedent-js";
+import { testMembers } from "./utility/harness";
+
+testMembers(
+  "Generates table with fields",
+  dedent`
+  /***
+   * My table.
+   * @field foo integer This is foo.
+   * @field bar string This is bar.
+   * @table TheTable
+   */
+  `,
+  dedent`
+    ---My table.
+    TheTable = {
+    \t---@type integer This is foo.
+    \tfoo = nil,
+
+    \t---@type string This is bar.
+    \tbar = nil
+    }
+  `
+);
+
+testMembers(
+  "Generates empty table",
+  dedent`
+  /***
+   * My empty table.
+   * @table Empty
+   */
+  `,
+  dedent`
+    ---My empty table.
+    Empty = {}
+  `
+);


### PR DESCRIPTION
Outputs:
```lua
Table = {}
```

Instead of
```lua
Table = {

}
```