### PR TITLE
Fix enum table not global

### DIFF
--- a/src/enum.ts
+++ b/src/enum.ts
@@ -64,7 +64,7 @@ export function addTableToEnumFields(docs: Doc[]): Doc[] {
         createAttribute(
           "table",
           { name: tableName, description: "" },
-          { isLocal: true }
+          { isLocal: false }
         )
       );
     }


### PR DESCRIPTION
Fix issue where enum table could be local when merging standalone enum fields.